### PR TITLE
Upgrade haystack & fix imports in tests

### DIFF
--- a/ai_dataset_generator/dataset_generator.py
+++ b/ai_dataset_generator/dataset_generator.py
@@ -62,7 +62,7 @@ class DatasetGenerator:
             )
 
             pred = self.prompt_node.run(
-                prompt_template=HaystackPromptTemplate(name="prompt_text", prompt_text=prompt_text),
+                prompt_template=HaystackPromptTemplate(prompt=prompt_text),
                 invocation_context=invocation_context,
             )[0]["results"]
 

--- a/ai_dataset_generator/samplers/__init__.py
+++ b/ai_dataset_generator/samplers/__init__.py
@@ -1,1 +1,1 @@
-from .samplers import single_label_task_sampler, random_sampler
+from ai_dataset_generator.samplers.samplers import single_label_task_sampler, random_sampler, ml_mc_sampler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 datasets
 langchain
-farm-haystack
+farm-haystack>=1.18.0

--- a/tests/test_dataset_sampler.py
+++ b/tests/test_dataset_sampler.py
@@ -2,7 +2,7 @@ import unittest
 
 from datasets import load_dataset
 
-from ai_dataset_generator.samplers.sampler import random_sampler, single_label_task_sampler, ml_mc_sampler
+from ai_dataset_generator.samplers import random_sampler, single_label_task_sampler, ml_mc_sampler
 
 
 def _flatten(l):


### PR DESCRIPTION
This PR pins the Haystack dependency to >= 1.18.0. The advantage is that torch won't be installed anymore, thus the installation is leaner and faster. Haystack 1.18.0 comes with a breaking change affecting how we use the HaystackPromptTemplate here, which is why I removed one parameter and renamed another.
While running the tests I noticed that the import doesn't work so this PR fixes that too.

Please note that after merging this you will need to run `pip install --upgrade farm-haystack` or `pip install -r requirements.txt` in a fresh environment.