### PR TITLE
Automatically infer TextLabelPrompt for QA and ClassLabelPrompt for Text Classification

### DIFF
--- a/examples/annotate_question_answering.py
+++ b/examples/annotate_question_answering.py
@@ -8,7 +8,7 @@ from ai_dataset_generator.dataset_transformations.question_answering import (
     preprocess_squad_format,
     postprocess_squad_format,
 )
-from ai_dataset_generator.prompts import TextLabelPrompt
+from ai_dataset_generator.prompts import TextLabelPrompt, infer_prompt_from_dataset
 
 
 def run(arguments):
@@ -16,11 +16,12 @@ def run(arguments):
     dataset = preprocess_squad_format(load_dataset(arguments.dataset, split=arguments.split))
     fewshot_examples = dataset.select([1, 2, 3])
 
-    prompt = TextLabelPrompt(
-        input_variables=arguments.input_variables,
-        target_variable=arguments.target_variable,
-        task_description=arguments.task_description,
-    )
+    # prompt = TextLabelPrompt(
+    #     input_variables=arguments.input_variables,
+    #     target_variable=arguments.target_variable,
+    #     task_description=arguments.task_description,
+    # )
+    prompt = infer_prompt_from_dataset(dataset)
 
     raw_prompt = prompt.get_prompt_text(fewshot_examples)
     print(raw_prompt)

--- a/examples/annotate_text_classes.py
+++ b/examples/annotate_text_classes.py
@@ -5,21 +5,24 @@ from argparse import ArgumentParser
 from datasets import load_dataset
 from haystack.nodes import PromptNode
 from ai_dataset_generator import DatasetGenerator
-from ai_dataset_generator.prompts import ClassLabelPrompt
+from ai_dataset_generator.prompts import ClassLabelPrompt, infer_prompt_from_dataset
 
 
 def run(arguments):
     """Generate annotations for unlabeled data for a given dataset and split."""
     dataset = load_dataset(arguments.dataset, split=arguments.split)
     fewshot_examples = dataset.select(random.sample(range(len(dataset)), arguments.num_fewshot_examples))
-    idx2label = dict(enumerate(fewshot_examples.features[arguments.target_variable].names))
 
-    prompt = ClassLabelPrompt(
-        input_variables=arguments.input_variables,
-        target_variable=arguments.target_variable,
-        label_options=idx2label,
-        task_description=arguments.task_description,
-    )
+    # idx2label = dict(enumerate(fewshot_examples.features[arguments.target_variable].names))
+    #
+    # prompt = ClassLabelPrompt(
+    #     input_variables=arguments.input_variables,
+    #     target_variable=arguments.target_variable,
+    #     label_options=idx2label,
+    #     task_description=arguments.task_description,
+    # )
+    prompt = infer_prompt_from_dataset(dataset)
+
     raw_prompt = prompt.get_prompt_text(fewshot_examples)
     print(raw_prompt)
 


### PR DESCRIPTION
This PR adds a `infer_prompt_from_dataset` function that automatically infers TextLabelPrompt or ClassLabelPrompt with the correct parameters from a dataset's meta data (if available).

Also adding three tests and changed two of the examples so that they now use `infer_prompt_from_dataset`.

for extractive question answering on SQuAD 2.0
```python
# prompt = TextLabelPrompt(
#     input_variables=arguments.input_variables,
#     target_variable=arguments.target_variable,
#     task_description=arguments.task_description,
# )
prompt = infer_prompt_from_dataset(dataset)
```

and for text classification on imdb:
```python
# idx2label = dict(enumerate(fewshot_examples.features[arguments.target_variable].names))
#
# prompt = ClassLabelPrompt(
#     input_variables=arguments.input_variables,
#     target_variable=arguments.target_variable,
#     label_options=idx2label,
#     task_description=arguments.task_description,
# )
prompt = infer_prompt_from_dataset(dataset)
```