### PR TITLE
fix: package name in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup(
     name='ai-dataset-generator',
     version='0.1.0',
     author='Jonas Golde, Julian Risch, Felix Hamborg',
-    email='jonas.golde@gmail.com',
     description='Leverage LLMs to generate datasets.',
-    packages=['ai-dataset-generator']
+    packages=['ai_dataset_generator']
 )


### PR DESCRIPTION
## Changes
setup.py used `-` instead of `_`, which gives an error when isntalling the repo via `pip install -e .`. This PR replaces `-` with `_`.
The email also throws a warning, which is why this PR removes the email


```
(ai_hacky_friday) ➜  ai-dataset-generator git:(squadv2) ✗ pip install -e .
Obtaining file:///Users/julian/deepset/dev/ai-dataset-generator
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [9 lines of output]
      running egg_info
      creating ai_dataset_generator.egg-info
      writing ai_dataset_generator.egg-info/PKG-INFO
      writing dependency_links to ai_dataset_generator.egg-info/dependency_links.txt
      writing top-level names to ai_dataset_generator.egg-info/top_level.txt
      writing manifest file 'ai_dataset_generator.egg-info/SOURCES.txt'
      /private/var/folders/mk/yhcj27g936vbjy3r6vm14m540000gn/T/pip-build-env-c0os0vj1/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py:265: UserWarning: Unknown distribution option: 'email'
        warnings.warn(msg)
      error: package directory 'ai-dataset-generator' does not exist
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```