### PR TITLE
Add pypi package workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,6 +5,23 @@ on:
     types: [published]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        pylint $(git ls-files '*.py') --fail-under 9.3
+
   build:
     name: Build distribution
     runs-on: ubuntu-latest
@@ -15,16 +32,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest pytest-sugar
-        python -m pip install pylint
-        python -m pip install -r requirements.txt
-    - name: Lint with pylint
-      run: python3 -m pylint fabricator
-    - name: Test with pytest
-      run: python3 -m pytest tests
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -42,6 +49,7 @@ jobs:
   publish-to-testpypi:
     name: Publish distribution to TestPyPI
     needs:
+      - lint
       - build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,68 +29,6 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  publish-to-pypi:
-    name: >-
-      Publish Release to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/fabricator-ai
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-  github-release:
-    name: >-
-      Sign fabricator distribution with Sigstore
-      and upload them to GitHub Release
-    needs:
-      - publish-to-pypi
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      id-token: write
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v1.2.3
-        with:
-          inputs: >-
-            ./dist/*.tar.gz
-            ./dist/*.whl
-      - name: Create GitHub Release
-        run: >-
-          gh release create
-          '${{ github.ref_name }}'
-          --notes ""
-      - name: Upload artifact signatures to GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        # Upload to GitHub Release using the `gh` CLI.
-        # `dist/` contains the built packages, and the
-        # sigstore-produced signatures and certificates.
-        run: >-
-          gh release upload
-          '${{ github.ref_name }}' dist/**
-          --repo '${{ github.repository }}'
-
   publish-to-testpypi:
     name: Publish distribution to TestPyPI
     needs:
@@ -115,3 +53,25 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: >-
+      Publish Release to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - publish-to-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fabricator-ai
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   lint:
+    name: Linting Checks
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,6 +1,8 @@
 name: Publish Release to PyPI
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,6 +15,12 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest pytest-sugar
+        python -m pip install pylint
+        python -m pip install -r requirements.txt
     - name: Lint with pylint
       run: python3 -m pylint fabricator
     - name: Test with pytest

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,8 +1,6 @@
-name: Publish Release PyPI
+name: Publish Release to PyPI
 
-on:
-  release:
-    types: [published]
+on: push
 
 jobs:
   build:
@@ -14,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -31,7 +29,7 @@ jobs:
 
   publish-to-pypi:
     name: >-
-      Publish fabricator Release to PyPI
+      Publish Release to PyPI
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
@@ -39,6 +37,9 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/fabricator-ai
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v3
@@ -47,9 +48,6 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
 
   github-release:
     name: >-
@@ -90,3 +88,28 @@ jobs:
           gh release upload
           '${{ github.ref_name }}' dist/**
           --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish distribution to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/fabricator-ai
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
+    - name: Lint with pylint
+      run: python3 -m pylint fabricator
+    - name: Test with pytest
+      run: python3 -m pytest tests
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -1,0 +1,113 @@
+name: Publish Release to (Test)PyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build fabricator distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build binary wheel and source tarball
+      run: python3 -m build
+    - name: Store distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish fabricator Release to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fabricator-ai
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign fabricator distribution with Sigstore
+      and upload them to GitHub Release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v1.2.3
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create GitHub Release
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --notes ""
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}' dist/**
+          --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish fabricator distribution to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/fabricator-ai
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -38,6 +38,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/fabricator-ai
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Download all the dists
@@ -99,6 +100,7 @@ jobs:
       url: https://test.pypi.org/p/fabricator-ai
 
     permissions:
+      contents: read
       id-token: write
 
     steps:

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -37,9 +37,6 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/fabricator-ai
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v3
@@ -48,6 +45,9 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TESTPYPI_TOKEN }}
 
   github-release:
     name: >-
@@ -99,10 +99,6 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/fabricator-ai
 
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v3
@@ -112,4 +108,5 @@ jobs:
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
+          user: __token__
+          password: ${{ secrets.TESTPYPI_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -1,10 +1,12 @@
-name: Publish Release to (Test)PyPI
+name: Publish Release PyPI
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build:
-    name: Build fabricator distribution
+    name: Build distribution
     runs-on: ubuntu-latest
 
     steps:
@@ -12,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -88,25 +90,3 @@ jobs:
           gh release upload
           '${{ github.ref_name }}' dist/**
           --repo '${{ github.repository }}'
-
-  publish-to-testpypi:
-    name: Publish fabricator distribution to TestPyPI
-    needs:
-      - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/fabricator-ai
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <p align="center">A flexible open-source framework to generate datasets with large language models.</p>
 <p align="center">
-<img alt="version" src="https://img.shields.io/badge/version-0.1-green">
+<img alt="version" src="https://img.shields.io/badge/version-0.2.0-green">
 <img alt="python" src="https://img.shields.io/badge/python-3.10-blue">
 <img alt="Static Badge" src="https://img.shields.io/badge/license-apache2.0-green">
 </p>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 ## News
 
+- **[10/23]** We released the first version of this repository on PyPI. You can install it via `pip install fabricator-ai`.
 - **[10/23]** Our paper got accepted at EMNLP 2023. You can find the preprint [here](https://arxiv.org/abs/2309.09582). You can find the experimental scripts under release v0.1.0.
 - **[09/23]** Support for `gpt-3.5-turbo-instruct` added in the new [Haystack](https://github.com/deepset-ai/haystack) release!
 - **[08/23]** Added several experimental scripts to investigate the generation and annotation ability of `gpt-3.5-turbo` on various downstream tasks + the influence of few-shot examples on the performance for different downstream tasks.
@@ -45,6 +46,11 @@ git clone git@github.com:flairNLP/fabricator.git
 cd fabricator
 conda create -y -n fabricator python=3.10
 conda activate fabricator
+pip install fabricator-ai
+```
+
+If you want to install in editable mode, you can use the following command:
+```
 pip install -e .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def requirements():
 
 setup(
     name='fabricator-ai',
-    version='0.1.1',
+    version='0.2.0-beta',
     author='Humboldt University Berlin, deepset GmbH',
     author_email="goldejon@informatik.hu-berlin.de",
     description='Conveniently generating datasets with large language models.',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from setuptools import setup, find_packages
 
 
@@ -12,11 +13,8 @@ setup(
     author='Humboldt University Berlin, deepset GmbH',
     author_email="goldejon@informatik.hu-berlin.de",
     description='Conveniently generating datasets with large language models.',
-    long_description="If you require textual datasets for specific tasks, you can utilize large language models "
-                     "that possess immense generation capability. fabricator enables you to conveniently create "
-                     "or annotate datasets to fine-tune your custom model. fabricator is constructed on "
-                     "deepset's haystack and huggingface's datasets libraries, to seamlessly integrate "
-                     "into existing NLP frameworks.",
+    long_description=Path("README.md").read_text(encoding="utf-8"),
+    long_description_content_type="text/markdown",
     package_dir={"": "src"},
     packages=find_packages("src"),
     license="Apache 2.0",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     license="Apache 2.0",
-    python_requires=">=3.8.0",
+    python_requires=">=3.8",
     install_requires=requirements(),
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def requirements():
 
 
 setup(
-    name='fabricator',
+    name='fabricator-ai',
     version='0.1.1',
     author='Humboldt University Berlin, deepset GmbH',
     author_email="goldejon@informatik.hu-berlin.de",


### PR DESCRIPTION
closes gh-73: 

On release, publish package to pypi. Changes:
- adjusted readme to install fabricator via pypi
- added workflow to publish package
- minor changes to setup (long description)