### PR TITLE
Symbolic Text Generation 

### DIFF
--- a/src/fabricator/nodes/__init__.py
+++ b/src/fabricator/nodes/__init__.py
@@ -1,0 +1,7 @@
+from .base import PromptNode
+from .nodes import GuidedPromptNode
+
+__all__ = [
+    "PromptNode",
+    "GuidedPromptNode",
+]

--- a/src/fabricator/nodes/base.py
+++ b/src/fabricator/nodes/base.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+
+from typing import Optional, Dict, Union
+
+from haystack.nodes import PromptNode as HaystackPromptNode
+from haystack.nodes.prompt import PromptTemplate as HaystackPromptTemplate
+
+
+class Node(ABC):
+    @abstractmethod
+    def run(self, prompt_template):
+        pass
+
+
+class PromptNode(Node):
+    def __init__(self, model_name_or_path: str, *args, **kwargs) -> None:
+        self._prompt_node = HaystackPromptNode(model_name_or_path, *args, **kwargs)
+
+    def run(
+        self,
+        prompt_template: Optional[Union[str, HaystackPromptTemplate]],
+        invocation_context: Optional[Dict[str, any]] = None,
+    ):
+        return self._prompt_node.run(prompt_template, invocation_context=invocation_context)[0]["results"]

--- a/src/fabricator/nodes/nodes.py
+++ b/src/fabricator/nodes/nodes.py
@@ -1,0 +1,49 @@
+import json
+
+from typing import Optional, Dict, Union
+
+from haystack.nodes import PromptNode as HaystackPromptNode
+from haystack.nodes.prompt import PromptTemplate as HaystackPromptTemplate
+
+from .base import Node
+
+try:
+    import outlines.models as models
+    import outlines.text.generate as generate
+
+    from pydantic import BaseModel
+
+    import torch
+except ImportError as exc:
+    raise ImportError("Try 'pip install outlines'") from exc
+
+
+class GuidedPromptNode(Node):
+    def __init__(
+        self,
+        model_name_or_path: str,
+        schema: Union[str, BaseModel],
+        max_length: int = 100,
+        device: Optional[str] = None,
+        model_kwargs: Dict = None,
+        manual_seed: Optional[int] = None,
+    ) -> None:
+        self.max_length = max_length
+        model_kwargs = model_kwargs or {}
+        self._model = models.transformers(model_name_or_path, device=device, **model_kwargs)
+        # JSON schema of class
+        if not isinstance(schema, str):
+            schema = json.dumps(schema.schema())
+
+        self._generator = generate.json(
+            self._model,
+            schema,
+            self.max_length,
+        )
+
+        self.rng = torch.Generator(device=device)
+        if manual_seed is not None:
+            self.rng.manual_seed(manual_seed)
+
+    def run(self, prompt_template: HaystackPromptTemplate, **kwargs):
+        return self._generator(prompt_template.prompt_text, rng=self.rng)


### PR DESCRIPTION
Initial draft/concept for symbolic text generation with [Outlines](https://github.com/outlines-dev/outlines). 

* The draft currently only includes the generation of JSON text (Outline also supports integers, choices, and regexes)
* I build a thin wrapper around the PromptNode. The default Node would still be haystack (but now imported with `from fabricator.nodes import PromptNode`)
* The new node `GuidedPromptNode` loads a local model for text generation (I think outline also supported OpenAI, etc)

Here an example script:
```python
from fabricator import DatasetGenerator
from fabricator.nodes import GuidedPromptNode
from fabricator.prompts import BasePrompt

from pydantic import BaseModel


# Define a pydantic model for the prompt, can also be just a JSON string 
# if you don't want to use pydantic
class MovieReview(BaseModel):
    movie_title: str
    movie_review: str

prompt = BasePrompt(
    task_description="Generate a short movie review.",
)

# Guided prompt node for JSON generation, pass in the pydantic model
guided_prompt_node = GuidedPromptNode("EleutherAI/pythia-70m", MovieReview, max_length=100)

generator = DatasetGenerator(guided_prompt_node)
generated_dataset = generator.generate(
    prompt_template=prompt,
    max_prompt_calls=1,
)

print(generated_dataset[0]["text"])
# Out: '{ "movie_title": "Movie_title", "movie_review": "Low bit. MT Number"\n}'
```

Outlines has more features, such as validation of output format and also return the corresponding class. 

Current problems with Outlines are dependency conflicts with haystack, because of pydantic. I must check if this still works with the build pipeline.




