### PR TITLE
Rectify typos in tutorials

### DIFF
--- a/tutorials/TUTORIAL-1_OVERVIEW.md
+++ b/tutorials/TUTORIAL-1_OVERVIEW.md
@@ -169,7 +169,7 @@ frameworks such as [flair](https://github.com/flairNLP/flair), deepset's [haysta
 ```python
 from fabricator import BasePrompt, DatasetGenerator
 
-prompt_template = BasePrompt(task_description="Generate a movie review.")
+prompt = BasePrompt(task_description="Generate a movie review.")
 
 prompt_node = PromptNode("google/flan-t5-base")
 

--- a/tutorials/TUTORIAL-3_ADVANCED-GENERATION.md
+++ b/tutorials/TUTORIAL-3_ADVANCED-GENERATION.md
@@ -43,7 +43,7 @@ Movie Review: {text}
 Sentiment: 
 ```
 
-## Inferring the Prompt rom Dataset Info
+## Inferring the Prompt from Dataset Info
 
 Huggingface Dataset objects provide the possibility to infer a prompt from the dataset. This can be achieved by using
 the `infer_prompt_from_dataset` function. This function takes a dataset


### PR DESCRIPTION
The `prompt_template` parameter in `.generate()` is passed wrongly and this PR addresses the same.